### PR TITLE
mark-devkit: Bump virtual/cron-0-r1

### DIFF
--- a/virtual/cron/cron-0-r1.ebuild
+++ b/virtual/cron/cron-0-r1.ebuild
@@ -1,0 +1,15 @@
+# Copyright 1999-2018 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Virtual for cron"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd"
+
+RDEPEND="|| ( sys-process/cronie
+		sys-process/vixie-cron
+		sys-process/bcron
+		sys-process/dcron
+		sys-process/fcron
+		sys-process/systemd-cron )"


### PR DESCRIPTION
Automatic bump of package virtual/cron-0-r1 for branch mark-xl by mark-bot