### PR TITLE
mark-devkit: Bump virtual/logger-0-r1

### DIFF
--- a/virtual/logger/logger-0-r1.ebuild
+++ b/virtual/logger/logger-0-r1.ebuild
@@ -1,0 +1,19 @@
+# Copyright 1999-2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+DESCRIPTION="Virtual for system loggers"
+SLOT="0"
+KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~ppc-aix ~x64-cygwin ~amd64-fbsd ~x86-fbsd ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris"
+
+RDEPEND="|| (
+	app-admin/metalog
+	app-admin/rsyslog
+	app-admin/socklog
+	app-admin/sysklogd
+	app-admin/syslog-ng
+	sys-freebsd/freebsd-usbin
+	sys-apps/busybox[syslog]
+	>=sys-apps/systemd-38
+)"


### PR DESCRIPTION
Automatic bump of package virtual/logger-0-r1 for branch mark-xl by mark-bot