### PR TITLE
mark-devkit: Bump app-misc/screen-5.0.1-r1

### DIFF
--- a/app-misc/screen/screen-5.0.1-r1.ebuild
+++ b/app-misc/screen/screen-5.0.1-r1.ebuild
@@ -89,7 +89,7 @@ src_configure() {
 src_compile() {
 	LC_ALL=POSIX emake comm.h term.h
 
-	emake -C doc screen.info
+	emake -C doc screen.texinfo
 	default
 }
 


### PR DESCRIPTION
Automatic bump of package app-misc/screen-5.0.1-r1 for branch mark-unstable by mark-bot