### PR TITLE
mark-devkit: Bump dev-libs/libmemcached-1.0.18-r4

### DIFF
--- a/dev-libs/libmemcached/files/libmemcached-1.0.18-autotools.patch
+++ b/dev-libs/libmemcached/files/libmemcached-1.0.18-autotools.patch
@@ -1,0 +1,61 @@
+* Automake 1.14+ fix for AC_PROG_* instantiation
+* Disable old GCC flags
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -13,10 +13,6 @@ m4_include([version.m4])
+ AC_PREREQ([2.61])
+ AC_INIT([libmemcached],VERSION_NUMBER,[http://libmemcached.org/])
+ 
+-# Setup the compilers early on
+-AC_PROG_CC([cc gcc clang])
+-AC_PROG_CXX([c++ g++ clang++])
+-
+ AC_CONFIG_AUX_DIR([build-aux])
+ AC_CONFIG_MACRO_DIR([m4])
+ 
+@@ -61,6 +57,10 @@ LT_LIB_M
+ 
+ AC_SUBST([lt_cv_dlopen_libs])
+ 
++# Setup the compilers early on
++AC_PROG_CC([cc gcc clang])
++AC_PROG_CXX([c++ g++ clang++])
++
+ 
+ AC_PROG_CC_C99
+ AS_IF([test "x${ac_cv_prog_cc_c99}" == "xno"],[AC_MSG_ERROR([No c99 compatible compiler found])])
+--- a/m4/ax_harden_compiler_flags.m4
++++ b/m4/ax_harden_compiler_flags.m4
+@@ -138,7 +138,6 @@
+            _APPEND_COMPILE_FLAGS_ERROR([-H])
+            _APPEND_COMPILE_FLAGS_ERROR([-g])
+            _APPEND_COMPILE_FLAGS_ERROR([-g3])
+-           _APPEND_COMPILE_FLAGS_ERROR([-fmudflapth])
+            _APPEND_COMPILE_FLAGS_ERROR([-fno-eliminate-unused-debug-types])
+            _APPEND_COMPILE_FLAGS_ERROR([-fno-omit-frame-pointer])
+            ],[
+@@ -213,7 +212,6 @@
+           _APPEND_COMPILE_FLAGS_ERROR([-Wunused-local-typedefs])
+           _APPEND_COMPILE_FLAGS_ERROR([-Wwrite-strings])
+           _APPEND_COMPILE_FLAGS_ERROR([-fwrapv])
+-          _APPEND_COMPILE_FLAGS_ERROR([-fmudflapt])
+           _APPEND_COMPILE_FLAGS_ERROR([-pipe])
+           _APPEND_COMPILE_FLAGS_ERROR([-fPIE -pie])
+           _APPEND_COMPILE_FLAGS_ERROR([-Wsizeof-pointer-memaccess])
+@@ -247,7 +245,6 @@
+            _APPEND_COMPILE_FLAGS_ERROR([-H])
+            _APPEND_COMPILE_FLAGS_ERROR([-g])
+            _APPEND_COMPILE_FLAGS_ERROR([-g3])
+-           _APPEND_COMPILE_FLAGS_ERROR([-fmudflapth])
+            _APPEND_COMPILE_FLAGS_ERROR([-fno-inline])
+            _APPEND_COMPILE_FLAGS_ERROR([-fno-eliminate-unused-debug-types])
+            _APPEND_COMPILE_FLAGS_ERROR([-fno-omit-frame-pointer])
+@@ -318,7 +315,6 @@
+           _APPEND_COMPILE_FLAGS_ERROR([-Wwrite-strings])
+           _APPEND_COMPILE_FLAGS_ERROR([-Wformat-security])
+           _APPEND_COMPILE_FLAGS_ERROR([-fwrapv])
+-          _APPEND_COMPILE_FLAGS_ERROR([-fmudflapt])
+           _APPEND_COMPILE_FLAGS_ERROR([-pipe])
+           _APPEND_COMPILE_FLAGS_ERROR([-fPIE -pie])
+           _APPEND_COMPILE_FLAGS_ERROR([-Wsizeof-pointer-memaccess])

--- a/dev-libs/libmemcached/libmemcached-1.0.18-r4.ebuild
+++ b/dev-libs/libmemcached/libmemcached-1.0.18-r4.ebuild
@@ -1,9 +1,6 @@
-# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-
-WANT_AUTOMAKE=1.13
+EAPI=7
 
 inherit autotools eutils multilib
 RESTRICT="test" # https://bugs.gentoo.org/show_bug.cgi?id=498250 https://bugs.launchpad.net/gentoo/+bug/1278023
@@ -14,7 +11,7 @@ SRC_URI="https://launchpad.net/${PN}/1.0/${PV}/+download/${P}.tar.gz"
 
 LICENSE="BSD"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ia64 ppc ppc64 s390 ~sh sparc x86 ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="*"
 IUSE="debug hsieh +libevent sasl static-libs"
 
 DEPEND="net-misc/memcached
@@ -22,11 +19,18 @@ DEPEND="net-misc/memcached
 	libevent? ( dev-libs/libevent )"
 RDEPEND="${DEPEND}"
 
+PATCHES=(
+	"${FILESDIR}/debug-disable-enable-1.0.18.patch"
+	"${FILESDIR}"/${P}-gcc7.patch
+	"${FILESDIR}"/libmemcached-1.0.18-autotools.patch
+)
+
 src_prepare() {
-	epatch "${FILESDIR}/debug-disable-enable-1.0.18.patch"
-	epatch "${FILESDIR}/continuum-1.0.18.patch"
-	epatch "${FILESDIR}"/${P}-gcc7.patch
+	default
+	eapply -p0 "${FILESDIR}/continuum-1.0.18.patch"
 	sed -i '6i CFLAGS = @CFLAGS@' Makefile.am
+	# Disable sphinx (seems broken)
+	sed -i '/include docs\/include.am/d' Makefile.am
 	sed -e "/_APPEND_COMPILE_FLAGS_ERROR(\[-fmudflapth\?\])/d" -i m4/ax_harden_compiler_flags.m4
 	eautoreconf
 }


### PR DESCRIPTION
Automatic bump of package dev-libs/libmemcached-1.0.18-r4 for branch mark-xl by mark-bot