### PR TITLE
mark-devkit: Bump virtual/mysql-5.6-r13

### DIFF
--- a/virtual/mysql/mysql-5.6-r13.ebuild
+++ b/virtual/mysql/mysql-5.6-r13.ebuild
@@ -1,0 +1,18 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+DESCRIPTION="Virtual for MySQL database server"
+SLOT="0/18"
+KEYWORDS="*"
+IUSE="embedded +server static"
+
+RDEPEND="|| (
+		>=dev-db/mariadb-10.0[embedded(-)?,server?,static?]
+		>=dev-db/mysql-${PV}[embedded(-)?,server?,static?]
+		dev-db/mysql-community
+		>=dev-db/percona-server-${PV}[embedded(-)?,server?,static?]
+		dev-db/mariadb-galera[embedded(-)?,server?,static?]
+		>=dev-db/mysql-cluster-7.3[embedded(-)?,server?,static?]
+	)
+"


### PR DESCRIPTION
Automatic bump of package virtual/mysql-5.6-r13 for branch mark-unstable by mark-bot