### PR TITLE
mark-devkit: [mark-xl] Bump app-emulation/qemu-10.2.0-r1

### DIFF
--- a/app-emulation/qemu/qemu-10.2.0-r1.ebuild
+++ b/app-emulation/qemu/qemu-10.2.0-r1.ebuild
@@ -532,6 +532,7 @@ DEPEND="${CDEPEND}
 "
 src_prepare() {
 	default
+	sed -e '/^pycotap =/d' pythondeps.toml -i
 	# Use correct toolchain to fix cross-compiling
 	tc-export AR AS LD NM OBJCOPY PKG_CONFIG RANLIB STRINGS
 	export WINDRES=${CHOST}-windres


### PR DESCRIPTION
Automatic bump of package app-emulation/qemu-10.2.0-r1 for branch mark-xl by mark-bot