### PR TITLE
mark-devkit: [mark-31] Bump app-emulation/open-vm-tools-12.5.2-r1

### DIFF
--- a/app-emulation/open-vm-tools/open-vm-tools-12.5.2-r1.ebuild
+++ b/app-emulation/open-vm-tools/open-vm-tools-12.5.2-r1.ebuild
@@ -62,7 +62,6 @@ DEPEND="${RDEPEND}
 "
 
 BDEPEND="
-	dev-util/glib-utils
 	virtual/pkgconfig
 	doc? ( app-doc/doxygen )
 "


### PR DESCRIPTION
Automatic bump of package app-emulation/open-vm-tools-12.5.2-r1 for branch mark-31 by mark-bot