### PR TITLE
mark-devkit: [mark-31] Bump app-emulation/libvirt-glib-5.0.0-r1

### DIFF
--- a/app-emulation/libvirt-glib/libvirt-glib-5.0.0-r1.ebuild
+++ b/app-emulation/libvirt-glib/libvirt-glib-5.0.0-r1.ebuild
@@ -21,7 +21,6 @@ RDEPEND="
 	>=dev-libs/glib-2.38.0:2
 	introspection? ( >=dev-libs/gobject-introspection-1.36.0:= )"
 DEPEND="${RDEPEND}
-	dev-util/glib-utils
 	dev-util/gtk-doc-am
 	>=dev-util/intltool-0.35.0
 	virtual/pkgconfig


### PR DESCRIPTION
Automatic bump of package app-emulation/libvirt-glib-5.0.0-r1 for branch mark-31 by mark-bot