### PR TITLE
mark-devkit: [mark-xl] Bump sys-auth/sssd-2.12.0-r1

### DIFF
--- a/sys-auth/sssd/sssd-2.12.0-r1.ebuild
+++ b/sys-auth/sssd/sssd-2.12.0-r1.ebuild
@@ -20,7 +20,7 @@ REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 BDEPEND="sys-libs/libcap
 	virtual/pkgconfig
 	${PYTHON_DEPS}
-	doc? ( app-text/doxygen )
+	doc? ( app-doc/doxygen )
 	man? (
 	  app-text/docbook-xml-dtd:4.5
 	  dev-libs/libxslt


### PR DESCRIPTION
Automatic bump of package sys-auth/sssd-2.12.0-r1 for branch mark-xl by mark-bot