### PR TITLE
Fix missing shebang in no-ed-its-sed patch causing ARM32 qemu/mchroot…

### DIFF
--- a/sys-devel/bc/files/bc-1.07.1-no-ed-its-sed.patch
+++ b/sys-devel/bc/files/bc-1.07.1-no-ed-its-sed.patch
@@ -1,13 +1,11 @@
-in Gentoo, everyone has sed.  no one really has ed.  tweak this minor script
-to use sed instead of ed.  the changes are straight forward:
-* change \$ to $
-* merge last two $,$ commands into one
-* delete w/q commands
+in MacaroniOS, everyone has sed. no one really has ed. tweak this minor script
+to use sed instead of ed.
 
 --- a/bc/fix-libmath_h
 +++ b/bc/fix-libmath_h
-@@ -1,9 +1,6 @@
+@@ -1,9 +1,7 @@
 -ed libmath.h <<EOS-EOS
++#!/bin/sh
 +sed -i libmath.h -e '
  1,1s/^/{"/
 -1,\$s/\$/",/


### PR DESCRIPTION
… build failures: Update bc-1.07.1-no-ed-its-sed.patch

bug reported on https://github.com/macaroni-os/mark-issues/issues/686