### PR TITLE
Update sqlite-3.50.0.ebuild to set --soname=legacy

### DIFF
--- a/dev-db/sqlite/sqlite-3.50.0.ebuild
+++ b/dev-db/sqlite/sqlite-3.50.0.ebuild
@@ -36,6 +36,7 @@ src_configure() {
 	options+=(
 		--enable-load-extension
 		--enable-threadsafe
+		--soname=legacy
 	)
 
 	# Support detection of misuse of SQLite API.


### PR DESCRIPTION
fix to https://github.com/macaroni-os/mark-issues/issues/724