### PR TITLE
mark-devkit: [mark-31] Bump dev-db/sqlite-3.50.0-r1

### DIFF
--- a/dev-db/sqlite/sqlite-3.50.0-r1.ebuild
+++ b/dev-db/sqlite/sqlite-3.50.0-r1.ebuild
@@ -36,6 +36,7 @@ src_configure() {
 	options+=(
 		--enable-load-extension
 		--enable-threadsafe
+		--soname=legacy
 	)
 
 	# Support detection of misuse of SQLite API.


### PR DESCRIPTION
Automatic bump of package dev-db/sqlite-3.50.0-r1 for branch mark-31 by mark-bot